### PR TITLE
✨ Use Ghola.Database to produce Tenant struct

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -58,18 +58,18 @@ defmodule Supavisor.Application do
     [
       PromEx,
       {Cluster.Supervisor, [topologies, [name: Supavisor.ClusterSupervisor]]},
-      Supavisor.Repo,
+      # Supavisor.Repo,
       # Start the Telemetry supervisor
-      SupavisorWeb.Telemetry,
+      # SupavisorWeb.Telemetry,
       # Start the PubSub system
-      {Phoenix.PubSub, name: Supavisor.PubSub},
+      # {Phoenix.PubSub, name: Supavisor.PubSub},
       # Start the Endpoint (http/https)
-      SupavisorWeb.Endpoint,
+      # SupavisorWeb.Endpoint,
       {
         PartitionSupervisor,
         child_spec: DynamicSupervisor, strategy: :one_for_one, name: Supavisor.DynamicSupervisor
-      },
-      Supavisor.Vault
+      }
+      # Supavisor.Vault
     ]
   end
 

--- a/lib/supavisor/cdc.ex
+++ b/lib/supavisor/cdc.ex
@@ -52,7 +52,7 @@ defmodule Supavisor.CDC do
     end
   end
 
-  def capture(%State{} = state) do
+  def capture(%State{} = state, tenant) do
     state.server_packets
     |> Enum.reverse()
     |> Enum.join()
@@ -77,12 +77,12 @@ defmodule Supavisor.CDC do
         {:ok, query}
 
       changed_packets ->
-        handle_changed_packets(changed_packets)
+        handle_changed_packets(changed_packets, tenant)
     end
   end
 
-  defp handle_changed_packets(changed_packets) do
-    case @writer_module.handle_changes(changed_packets) do
+  defp handle_changed_packets(changed_packets, tenant) do
+    case @writer_module.handle_changes(changed_packets, tenant) do
       {:ok, changed_ids} ->
         changed_ids = Enum.map_join(changed_ids, ", ", &"'#{&1}'")
         query = "SELECT unnest(ARRAY[#{changed_ids}]::TEXT[]) AS changed_ids;"

--- a/lib/supavisor/cdc.ex
+++ b/lib/supavisor/cdc.ex
@@ -15,6 +15,10 @@ defmodule Supavisor.CDC do
     %State{db_namespace: db_namespace}
   end
 
+  def reset(%State{} = state) do
+    %State{db_namespace: state.db_namespace}
+  end
+
   def change(bin, %State{in_transaction?: false} = state) do
     state = %{state | client_packets: [bin | state.client_packets]}
 

--- a/lib/supavisor/cdc.ex
+++ b/lib/supavisor/cdc.ex
@@ -11,8 +11,8 @@ defmodule Supavisor.CDC do
 
   @writer_module Application.compile_env!(:supavisor, :writer_module)
 
-  def change(bin) do
-    change(bin, %State{})
+  def init(db_namespace) do
+    %State{db_namespace: db_namespace}
   end
 
   def change(bin, %State{in_transaction?: false} = state) do

--- a/lib/supavisor/cdc/state.ex
+++ b/lib/supavisor/cdc/state.ex
@@ -9,5 +9,6 @@ defmodule Supavisor.CDC.State do
   * server_packets: the packets we have received from the server (postgres)
   """
 
-  defstruct in_transaction?: false, client_packets: [], server_packets: []
+  @enforce_keys [:db_namespace]
+  defstruct client_packets: [], db_namespace: nil, in_transaction?: false, server_packets: []
 end

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -190,7 +190,7 @@ defmodule Supavisor.ClientHandler do
   end
 
   def handle_event(_, :capture, :cdc, data) do
-    case CDC.capture(data.cdc_state) do
+    case CDC.capture(data.cdc_state, data.tenant) do
       {:ok, query} ->
         {:next_state, :busy, data, {:next_event, :internal, {:tcp, nil, query}}}
 

--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -19,8 +19,8 @@ defmodule Supavisor.Monitoring.PromEx do
       # PromEx built in plugins
       Plugins.Application,
       Plugins.Beam,
-      {Plugins.Phoenix, router: SupavisorWeb.Router, endpoint: SupavisorWeb.Endpoint},
-      Plugins.Ecto,
+      # {Plugins.Phoenix, router: SupavisorWeb.Router, endpoint: SupavisorWeb.Endpoint},
+      # Plugins.Ecto,
 
       # Custom PromEx metrics plugins
       {OsMon, poll_rate: poll_rate},

--- a/lib/supavisor/tenants.ex
+++ b/lib/supavisor/tenants.ex
@@ -8,6 +8,9 @@ defmodule Supavisor.Tenants do
 
   alias Supavisor.Tenants.Tenant
 
+  @lookup_mfa Application.compile_env!(:supavisor, :tenant_lookup_mfa) ||
+                {__MODULE__, :do_get_tenant_by_external_id, 1}
+
   @doc """
   Returns the list of tenants.
 
@@ -39,6 +42,12 @@ defmodule Supavisor.Tenants do
 
   @spec get_tenant_by_external_id(String.t()) :: Tenant.t() | nil
   def get_tenant_by_external_id(external_id) do
+    {module, function, 1} = @lookup_mfa
+    apply(module, function, [external_id])
+  end
+
+  @doc false
+  def original_get_tenant_by_external_id(external_id) do
     Tenant
     |> Repo.get_by(external_id: external_id)
   end

--- a/lib/supavisor/tenants/tenant.ex
+++ b/lib/supavisor/tenants/tenant.ex
@@ -18,6 +18,7 @@ defmodule Supavisor.Tenants.Tenant do
     field(:db_user, :string)
     field(:external_id, :string)
     field(:pool_size, :integer)
+    field(:db_namespace, :string, virtual: true)
 
     timestamps()
   end


### PR DESCRIPTION
- Add `db_namespace` as a virtual field in Tenant
- Allow injection of a tenant lookup function
- Get the DB namespace into CDC state and use it in place of hard-coded `salesforce` namespace
- Use the tenant's external ID (aka Resource permaslug) when writing changes
- Comment out unnecessary processes/PromEx plugins